### PR TITLE
migrationファイルの反映漏れ対応

### DIFF
--- a/db/migrate/20240621054216_add_confirmation_token_to_users.rb
+++ b/db/migrate/20240621054216_add_confirmation_token_to_users.rb
@@ -1,0 +1,8 @@
+class AddConfirmationTokenToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :confirmation_token, :string
+    add_column :users, :unconfirmed_email, :string
+    add_column :users, :confirmed_at, :datetime
+    add_column :users, :confirmation_sent_at, :datetime
+  end
+end


### PR DESCRIPTION
gem deviseのconfirmation機能追記に伴う、カラム追加用
migrationファイルが前回のpullrequrestから漏れていたため追加