### PR TITLE
devise送信メールのviewの調整とリダイレクトメソッドの修正

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -24,7 +24,11 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
   # end
 
   # The path used after confirmation.
-  def after_confirmation_path_for
-    homes_path
+  def after_confirmation_path_for(resource_name, resource)
+    if signed_in?(resource_name)
+      homes_path
+    else
+      new_session_path(resource_name)
+    end
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -60,7 +60,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   #   super(resource)
   # end
   # ユーザー情報編集後のリダイレクト先の変更
-  def after_update_path_for
+  def after_update_path_for(resource)
     profile_path
   end
 end

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,5 +1,7 @@
-<p>Welcome <%= @email %>!</p>
+<p>こんにちは。 <%= @resource.name %>さん</p>
+<p>Oko_logをご利用いただきありがとうございます</p>
 
-<p>You can confirm your account email through the link below:</p>
+<p>アカウントの認証を受付しました</p>
+<p>下記のリンクからアカウントの認証を行なってください</p>
 
-<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>
+<p><%= link_to 'アカウントを認証する', confirmation_url(@resource, confirmation_token: @token) %></p>

--- a/app/views/devise/mailer/email_changed.html.erb
+++ b/app/views/devise/mailer/email_changed.html.erb
@@ -1,7 +1,8 @@
-<p>Hello <%= @email %>!</p>
+<p>こんにちは。 <%= @name %>さん!</p>
+<p>いつもOko_logをご利用いただきありがとうございます。</p>
 
 <% if @resource.try(:unconfirmed_email?) %>
-  <p>We're contacting you to notify you that your email is being changed to <%= @resource.unconfirmed_email %>.</p>
+  <p>メールアドレスが次のように変更されることをお知らせするためにご連絡しています。<%= @resource.unconfirmed_email %>.</p>
 <% else %>
-  <p>We're contacting you to notify you that your email has been changed to <%= @resource.email %>.</p>
+  <p>メールアドレスが次のように変更されたことをお知らせするためにご連絡しています。 <%= @resource.email %></p>
 <% end %>

--- a/app/views/devise/mailer/password_change.html.erb
+++ b/app/views/devise/mailer/password_change.html.erb
@@ -1,3 +1,5 @@
-<p>Hello <%= @resource.name %>!</p>
+<p>こんにちは <%= @resource.name %>さん!</p>
+<p>いつもOko_logをご利用いただきありがとうございます。</p>
 
-<p>We're contacting you to notify you that your password has been changed.</p>
+<p>パスワードが変更されたことをお知らせするためにご連絡させていただきました</p>
+<p>パスワードの変更にお心あたりがない場合、すぐにご確認ください</p>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,10 @@
-<p>Hello <%= @resource.email %>!</p>
+<p>こんにちは <%= @resource.name %>さん!</p>
+<p>いつもOko_logをご利用いただきありがとうございます。</p>
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+<p>パスワードの変更を受付いたしました。下記リンクよりパスワードの再設定を行なってください</p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+<p><%= link_to 'パスワードを変更する', edit_password_url(@resource, reset_password_token: @token) %></p>
 
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
+
+<p>リンクにアクセスして新しいパスワードを作成するまで、パスワードは変更されません。</p>
+

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -132,7 +132,7 @@ Devise.setup do |config|
   # config.send_email_changed_notification = false
 
   # Send a notification email when the user's password is changed.
-  # config.send_password_change_notification = false
+  config.send_password_change_notification = true
 
   # ==> Configuration for :confirmable
   # A period that the user is allowed to access the website even without


### PR DESCRIPTION
deciseの機能を利用したメール送信のviewの調整とリダイレクト先の修正を行いました

- [x] devise confirmantion機能のメールフォーマットの修正
- [x] devise password変更時の送信メールフォーマットの修正 
- [x] deviseにてパスワード変更時にメールが送られるように設定変更 
- [x] devise メールアドレス変更時のメールフォーマットの修正 
- [x] devise パスワードリセット時のメールフォーマットの修正
- [x] 認証時のリダイレクト先のメソッドの修正