### PR TITLE
ドメイン名のミスを変更

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -82,7 +82,7 @@ Rails.application.configure do
     :address        => ENV['MAILGUN_SMTP_SERVER'],
     :user_name      => ENV['MAILGUN_SMTP_LOGIN'],
     :password       => ENV['MAILGUN_SMTP_PASSWORD'],
-    :domain         => 'oko-log-app-ffa0745e6641.heroku.com',
+    :domain         => 'oko-log-app-ffa0745e6641.herokuapp.com',
     :authentication => :plain,
   }
   config.action_mailer.default_url_options = { host: Settings.host, protocol: Settings.protocol }


### PR DESCRIPTION
認証メールに記載されているリンクがエラーとなるため、mailerに設定されているドメイン名を修正